### PR TITLE
Reworked infinite scroll logic

### DIFF
--- a/src/com/infinite-scroll.js
+++ b/src/com/infinite-scroll.js
@@ -94,10 +94,12 @@
 			if (ctn.length) {
 				var y = win.scrollTop();
 				
-				var relY = Math.min(y - ctn.offset().top + winH);
-				var relP = relY / ctn.height();
+				//y of the bottom of the container 
+				//relative to the bottom of the screen;
+				var relY = (y - (ctn.offset().top + ctn.height()) + winH);
+				var relP = relY / winH;
 
-				if (relP >= o.triggerPercentage && relP <= 1) {
+				if (relP >= -o.triggerPercentage && relP <= 1) {
 					loadNextPage(o.callback);
 				}
 			}


### PR DESCRIPTION
The infinite scroll logic was broken. The more content there was, the faster the infinite scroll was triggered.

The reworked logic is based on the bottom of the infinite scroll container relative to the bottom of the window. Let's say that the trigger percentage is 0.8. That means the infinite scroll will load more content when the bottom of the infinite container is 0.8 * windowHeight under the bottom of the window. I think this is the basic behaviour of a infinite scroll: you want to laod more content before the bottom of the infinite scroll container is visible.

This logic is more stable than the previous one which frankly, I didn't understand.