### PR TITLE
Normalize data-attr

### DIFF
--- a/src/modules/auto-toggle-class-on-scroll.js
+++ b/src/modules/auto-toggle-class-on-scroll.js
@@ -20,9 +20,9 @@
 	var ATTR_PREFIX = 'data-toggle-class-on-scroll-';
 
 	var ATTR_ADD_BEFORE = ATTR_PREFIX + 'add-before';
-	var ATTR_REM_BEFORE = ATTR_PREFIX + 'remove-before';
+	var ATTR_REM_BEFORE = ATTR_PREFIX + 'rem-before';
 	var ATTR_ADD_AFTER = ATTR_PREFIX + 'add-after';
-	var ATTR_REM_AFTER = ATTR_PREFIX + 'remove-after';
+	var ATTR_REM_AFTER = ATTR_PREFIX + 'rem-after';
 	var ATTR_REF_COMMON_ANCESTOR = ATTR_PREFIX + 'ref-common-ancestor';
 	var ATTR_REF = ATTR_PREFIX + 'ref';
 	var ATTR_SCREEN_OFFSET = ATTR_PREFIX + 'screen-offset';


### PR DESCRIPTION
Tired of having to look up if we are using "remove" or "rem" in the data-attr name. Changed "remove" in this file to use "rem" like elsewhere. 

Also, it's sexier.