### PR TITLE
Change scope default value in auto-change-state-hover

### DIFF
--- a/src/modules/auto-change-state-hover.js
+++ b/src/modules/auto-change-state-hover.js
@@ -16,7 +16,7 @@
 	var findTargetItemIfAvailable = function (item, target) {
 		//Find target if present
 		if (target) {
-			var scope = site;
+			var scope = item;
 			var commonAncestor = item.attr(BUTTON_TARGET_COMMON_ANCESTOR_ATTR);
 
 			if (commonAncestor) {


### PR DESCRIPTION
Changed the default value of the scope for the target from #site to the item itself.