### PR TITLE
Add strategy PreventEvents to site-scroll

### DIFF
--- a/src/modules/site-scroll.js
+++ b/src/modules/site-scroll.js
@@ -16,30 +16,122 @@
 	
 	var win = $(window);
 	var html = $('html');
+
+	var site = $('site');
+
+	var selectors = {
+		scrollingZone: '.js-scrolling-zone',
+		scrollingZoneContent: '.js-scrolling-zone-content'
+	}
 	
+	var keys = {
+		'ArrowDown': true,
+		'ArrowUp': true,
+		'End': true,
+		'Home': true,
+		'PageDown': true,
+		'PageUp': true
+	};
+
 	var fixScroll = function (value) {
 		$('.js-fix-scroll-pad').css({paddingRight: value || ''});
 		$('.js-fix-scroll-right').css({right: value || ''});
 		$('.js-fix-scroll-margin').css({marginRight: value || ''});
 	};
-	
-	var addScroll = function () {
-		html.removeClass('no-scroll');
-		fixScroll(0);
+
+	var getWheelDirection = function (e) {
+		var delta = null;
+		var direction = false;
+
+		if (e.wheelDelta) {
+			delta = e.wheelDelta / 60;
+		} else if (e.detail) {
+			delta = -e.detail / 2;
+		}
+		if (delta !== null) {
+			direction = delta > 0 ? 'up' : 'down';
+		}
+		return direction;
+	}
+
+	var preventDefault = function (e) {
+		var scrollingZone = $(e.target).closest(selectors.scrollingZone);
+		var shouldPrevent = false;
+		
+		if (scrollingZone.length > 0) {
+			var scrollingZoneHeight = scrollingZone.height() || 0;
+			var scrollingZoneContent = scrollingZone.find(selectors.scrollingZoneContent);
+			var scrollingZoneContentHeight = scrollingZoneContent.height() || 0;
+			var scrollingStartOffset = scrollingZone.offset().top;
+			var scrollingDistanceTotal = scrollingZoneContentHeight - scrollingZoneHeight;
+			var scrollingDistance = -(scrollingZoneContent.offset().top - scrollingStartOffset);
+			var direction = getWheelDirection(e);
+
+			if (scrollingDistanceTotal <= 0 ||
+				direction == 'down' && scrollingDistance == scrollingDistanceTotal ||
+				direction == 'up' && scrollingDistance == 0) {
+				shouldPrevent = true;
+			}
+		}
+		else {
+			shouldPrevent = true;
+		}
+		if (shouldPrevent) {
+			e = e || window.event;
+			if (e.preventDefault) {
+				e.preventDefault();
+			}
+			e.returnValue = false;
+		}
 	};
-	
-	var removeScroll = function () {
-		if (!html.hasClass('no-scroll')) {
-			var x = win.width();
-			html.addClass('no-scroll');
-			fixScroll(win.width() - x);
+
+	var preventDefaultForScrollKeys = function (e) {
+		if (keys[e.key]) {
+			preventDefault(e);
+			return false;
+		}
+	};
+
+	var addScroll = function (key, data) {
+		var strategy = data.strategy || 'hideOverflow'; //hideOverflow or preventEvents
+
+		if (strategy == 'preventEvents') {
+			if (window.removeEventListener) {
+				window.removeEventListener('DOMMouseScroll', preventDefault, false);
+			}
+			window.onmousewheel = document.onmousewheel = null; 
+			window.onwheel = null;
+			window.ontouchmove = null;
+			document.onkeydown = null;
+		}
+		else {
+			html.removeClass('no-scroll');
+			fixScroll(0);
 		}
 	};
 	
-	var init = function () {
-		
+	var removeScroll = function (key, data) {
+		var strategy = data.strategy || 'hideOverflow'; //hideOverflow or preventEvents
+
+		if (strategy == 'preventEvents') {
+			if (window.addEventListener) {// older FF
+				window.addEventListener('DOMMouseScroll', preventDefault, false);
+			}
+			window.onwheel = preventDefault; // modern standard
+			window.onmousewheel = document.onmousewheel = preventDefault; // older browsers, IE
+			window.ontouchmove = preventDefault; // mobile
+			document.onkeydown = preventDefaultForScrollKeys;
+		}
+		else {
+			if (!html.hasClass('no-scroll')) {
+				var x = win.width();
+				html.addClass('no-scroll');
+				fixScroll(win.width() - x);
+			}
+		}
+
 	};
-	
+
 	var actions = function () {
 		return {
 			site: {
@@ -50,7 +142,6 @@
 	};
 
 	App.modules.exports('siteScroll', {
-		init: init,
 		actions: actions
 	});
 	

--- a/src/modules/site-scroll.js
+++ b/src/modules/site-scroll.js
@@ -9,7 +9,17 @@
  *      -pad : Add/remove padding-right scrollbar size fix
  *      -right : Add/remove right scrollbar size fix
  *      -margin : Add/remove margin-right scrollbar size fix
+
+ *  Strategies
+ *      You can pass a strategy in the data object when notifying site addScroll/removeScroll
+ *      - hideOverflow (default): Add css to limit the overflow of html and body
+ *      - preventEvent: Blocks mousewheel, swipe, and some keys events to disable scrolling without changing the css
+
+ *  Scrolling zone
+ *      For the preventEvent strategy, it is possible to have a scrolling zone 
+ *      where the events wont be block if the zone is scrollable
  */
+
 (function ($, undefined) {
 
 	'use strict';

--- a/src/modules/site-scroll.js
+++ b/src/modules/site-scroll.js
@@ -13,10 +13,11 @@
  *  Strategies
  *      You can pass a strategy in the data object when notifying site addScroll/removeScroll
  *      - hideOverflow (default): Add css to limit the overflow of html and body
- *      - preventEvent: Blocks mousewheel, swipe, and some keys events to disable scrolling without changing the css
+ *      - preventEvent: Blocks mousewheel, swipe, and some keys events to disable
+ *        scrolling without changing the css
 
  *  Scrolling zone
- *      For the preventEvent strategy, it is possible to have a scrolling zone 
+ *      For the preventEvent strategy, it is possible to have a scrolling zone
  *      where the events wont be block if the zone is scrollable
  */
 
@@ -34,7 +35,7 @@
 
 	var strategies = {
 		preventEvent: {
-			add: function() {
+			add: function () {
 				if (window.removeEventListener) {
 					window.removeEventListener('DOMMouseScroll', preventDefault, false);
 				}
@@ -43,7 +44,7 @@
 				window.ontouchmove = null;
 				document.onkeydown = null;
 			},
-			remove: function() {
+			remove: function () {
 				if (window.addEventListener) {// older FF
 					window.addEventListener('DOMMouseScroll', preventDefault, false);
 				}
@@ -54,11 +55,11 @@
 			}
 		},
 		hideOverflow: {
-			add: function() {
+			add: function () {
 				html.removeClass('no-scroll');
 				fixScroll(0);
 			},
-			remove: function() {
+			remove: function () {
 				if (!html.hasClass('no-scroll')) {
 					var x = win.width();
 					html.addClass('no-scroll');
@@ -66,7 +67,7 @@
 				}
 			}
 		}
-	}
+	};
 	
 	var keys = {
 		ArrowDown: true,
@@ -136,9 +137,9 @@
 		}
 	};
 
-	var getStrategy = function(data) {
+	var getStrategy = function (data) {
 		return data && data.strategy ? data.strategy : 'hideOverflow';
-	}
+	};
 
 	var addScroll = function (key, data) {
 		strategies[getStrategy(data)].add();

--- a/src/modules/site-scroll.js
+++ b/src/modules/site-scroll.js
@@ -22,15 +22,15 @@
 	var selectors = {
 		scrollingZone: '.js-scrolling-zone',
 		scrollingZoneContent: '.js-scrolling-zone-content'
-	}
+	};
 	
 	var keys = {
-		'ArrowDown': true,
-		'ArrowUp': true,
-		'End': true,
-		'Home': true,
-		'PageDown': true,
-		'PageUp': true
+		ArrowDown: true,
+		ArrowUp: true,
+		End: true,
+		Home: true,
+		PageDown: true,
+		PageUp: true
 	};
 
 	var fixScroll = function (value) {
@@ -52,7 +52,7 @@
 			direction = delta > 0 ? 'up' : 'down';
 		}
 		return direction;
-	}
+	};
 
 	var preventDefault = function (e) {
 		var scrollingZone = $(e.target).closest(selectors.scrollingZone);
@@ -99,7 +99,7 @@
 			if (window.removeEventListener) {
 				window.removeEventListener('DOMMouseScroll', preventDefault, false);
 			}
-			window.onmousewheel = document.onmousewheel = null; 
+			window.onmousewheel = document.onmousewheel = null;
 			window.onwheel = null;
 			window.ontouchmove = null;
 			document.onkeydown = null;

--- a/src/modules/site-scroll.js
+++ b/src/modules/site-scroll.js
@@ -27,8 +27,6 @@
 	var win = $(window);
 	var html = $('html');
 
-	var site = $('site');
-
 	var selectors = {
 		scrollingZone: '.js-scrolling-zone',
 		scrollingZoneContent: '.js-scrolling-zone-content'


### PR DESCRIPTION
Our current site-scroll add/removeScroll is working but with some drawbacks:
- Not working on iOS (can be fixed but scrolls back to top)
- Breaks all sticky behavior, which is preventing us the use of a very useful trick.

After some giving some thought to the problem and with the help of @PascalPiche  and @fhamon , here is a first draft of how we could manage to have others options -- or strategies -- for adding/removing the scroll. 

So this PR does 1) adds a way to select a strategy, keeping the current one as default and 2) creates a new strategy which prevent events who could induce a scroll. Like the other strategy, it's not perfect but has different drawbacks and can be useful in certain occasions.

Let's discuss!