### PR TITLE
Replaced concat selectors for cleaner traversing methods

### DIFF
--- a/src/com/flickity.js
+++ b/src/com/flickity.js
@@ -67,15 +67,13 @@
 			if (!d) {
 				return $();
 			}
-			var currentSlide = d.selectedIndex;
-			return slider.find(o.cellSelector + ':eq(' + currentSlide + ')');
+			return slider.find(o.cellSelector).eq(d.selectedIndex);
 		};
 
 		var setActiveSlideSeen = function () {
 			getCurrentSlide().addClass(o.seenClass);
 			slider.find(o.cellSelector + '.' + o.seenClass).each(function () {
-				slider.find('.flickity-page-dots li:eq(' + $(this).index() + ')')
-					.addClass(o.seenClass);
+				slider.find('.flickity-page-dots li').eq($(this).index()).addClass(o.seenClass);
 			});
 		};
 		
@@ -111,9 +109,7 @@
 				//set slide aria-label on corresponding page dot
 				slider.find('.flickity-page-dots li').each(function (i) {
 					var t = $(this);
-					var ariaLabel = slider.find(o.cellSelector + ':eq(' + i + ')')
-						.attr('aria-label');
-					
+					var ariaLabel = slider.find(o.cellSelector).eq(i).attr('aria-label');
 					if (!!ariaLabel) {
 						t.attr('aria-label', ariaLabel);
 					}


### PR DESCRIPTION
What the title says. I think it's a bit cleaner, simpler way to read it.