### PR TITLE
Strip query string from fragment

### DIFF
--- a/src/pages/default-detail-page.js
+++ b/src/pages/default-detail-page.js
@@ -25,7 +25,7 @@
 		var onFragmentChanged = function (key, data) {
 			var frag = !!data ? data : '';
 
-			changer.navigateTo(frag.split('/')[0]);
+			changer.navigateTo(frag.split('?')[0].split('/')[0]);
 		};
 		
 		var init = function () {


### PR DESCRIPTION
Query string should always be stripped from fragment to find current article handle. For example, in case of a short url, all the "utm" query string must not be evaluated to find the article.