### PR TITLE
Change State: Process a list of elements instead of only one

### DIFF
--- a/src/modules/change-state.js
+++ b/src/modules/change-state.js
@@ -247,7 +247,9 @@
 			var isMaxWidthValid = (!!maxWidth && window.mediaQueryMaxWidth(maxWidth)) || !maxWidth;
 			
 			if (isMinWidthValid && isMaxWidthValid) {
-				processItem(data.item, data.state, data.action, data.callbacks);
+				data.item.each(function () {
+					processItem($(this), data.state, data.action, data.callbacks);
+				});
 			}
 		}
 	};


### PR DESCRIPTION
This would make change state way more nicer to write.

Before: 
```js
$('div').each(function () {
	App.modules.notify('changeState.update', {
		item: $(this),
		state: 'foo',
		action: 'on'
	});
});
```
With my proposal:

```js
App.modules.notify('changeState.update', {
	item: $('div'),
	state: 'foo',
	action: 'on'
});
```

This also have the byproduct of not trowing when an empty list of item is passed in the notify.