### PR TITLE
Filter Algolia Hits

### DIFF
--- a/src/com/algolia-search.js
+++ b/src/com/algolia-search.js
@@ -29,7 +29,11 @@
 				return memo;
 			}, {});
 		};
-		
+
+		var filterHits = function (rCtn, resultContent, content, val) {
+			return content.hits;
+		};
+
 		var defaultOptions = {
 			inputSelector: '.js-algolia-input',
 			resultsCtnSelector: '.js-algolia-results-ctn',
@@ -45,6 +49,7 @@
 			facetFilters: null,
 			facetFiltersAttr: 'data-algolia-facet-filters',
 			onCreateResultsTemplatingObject: createResultsTemplatingObject,
+			filterHits: filterHits,
 			defaultResultsTemplateString: '<div><a href="__url__">__title__</a></div>',
 			defaultFacets: 'lang',
 			defaultFacetFilters: 'lang:' + lg,
@@ -97,7 +102,9 @@
 		};
 		
 		var applyTemplate = function (rCtn, resultContent, content, val) {
-			if (!!content.nbHits) {
+			var hits = o.filterHits(rCtn, resultContent, content, val);
+
+			if (!!hits.length) {
 				var tmplString = !!rCtn.find(o.resultsItemTemplateSelector).length ?
 					rCtn.find(o.resultsItemTemplateSelector).text() :
 					o.defaultResultsTemplateString;
@@ -109,8 +116,8 @@
 				tmplString = tmplString.replace(/%5B/g, '[').replace(/%5D/g, ']');
 				
 				var tplt = _.template(tmplString);
-				
-				_.each(content.hits, function (t) {
+
+				_.each(hits, function (t) {
 					var cleanData = o.onCreateResultsTemplatingObject(t, o);
 					var newItem = tplt(cleanData);
 					App.callback(o.beforeAppendNewItem, [


### PR DESCRIPTION
Hello ! 👋 

This feature can be useful when Algolia return a result that we may want to remove from the results list beacause it's missing vital data or something.

By default everything is working the same as before.

NB: If we have a `x results found` label in our search ui, the number should reflect the filtered list and not Algolia's `nbHits`.