### PR TITLE
Fix empty updateQsFragment

### DIFF
--- a/src/modules/url-changer.js
+++ b/src/modules/url-changer.js
@@ -199,7 +199,10 @@
 	var onUpdateQsFragment = function (key, options, e) {
 		if ($.isPlainObject(options.qs)) {
 			var oldQsFragmentString = App.routing.querystring.stringify(currentQsFragment);
-
+			if (!oldQsFragmentString.length) {
+				oldQsFragmentString = '?';
+			}
+			
 			//Update currentQsFragment
 			$.extend(currentQsFragment, options.qs);
 			


### PR DESCRIPTION
When checking the current QS, if there is none, stringify will return an empty string. In this case, the condition for the if is always true if we update fragment from empty QS to another empty QS. in this case, we do not want fragment changed to be raised