### PR TITLE
remove old documentation no longer relevant

### DIFF
--- a/src/modules/auto-sync-property.js
+++ b/src/modules/auto-sync-property.js
@@ -17,8 +17,6 @@
  *
  *      - data-sync-property-from :
  *          : JQuery Selector to identify the element used to read the value.
- *          : By default will use a scope from the #site element
- *          : (see common ancestor for alternative selection)
  *
  *      OPTIONAL :
  *


### PR DESCRIPTION
if no common ancestor, default scope is the element syncing, not #site