### PR TITLE
Changed commas for spaces

### DIFF
--- a/src/modules/change-state.js
+++ b/src/modules/change-state.js
@@ -12,9 +12,9 @@
  *      - data-{state}-state-follower : List of selector separated by ','
  *      - data-{state}-state-follower-common-ancestor (if not present: this will be used)
  *
- *      - data-{state}-state-notify-on: custom list of notification separated by ' ' (space)
+ *      - data-{state}-state-notify-on: custom list of notification separated by ' ' (space) or ','
  *             called when switching state to on. Data passed : {item:this}
- *      - data-{state}-state-notify-off: custom list of notification separated by ' ' (space)
+ *      - data-{state}-state-notify-off: custom list of notification separated by ' ' (space) or ','
  *             called when switching state to off. Data passed : {item:this}
  *
  *  NOTIFY IN :

--- a/src/modules/change-state.js
+++ b/src/modules/change-state.js
@@ -12,9 +12,9 @@
  *      - data-{state}-state-follower : List of selector separated by ','
  *      - data-{state}-state-follower-common-ancestor (if not present: this will be used)
  *
- *      - data-{state}-state-notify-on: custom list of notification separated by ','
+ *      - data-{state}-state-notify-on: custom list of notification separated by ' ' (space)
  *             called when switching state to on. Data passed : {item:this}
- *      - data-{state}-state-notify-off: custom list of notification separated by ','
+ *      - data-{state}-state-notify-off: custom list of notification separated by ' ' (space)
  *             called when switching state to off. Data passed : {item:this}
  *
  *  NOTIFY IN :
@@ -48,11 +48,11 @@
 
 	var notifyChanges = function (notifyOn, notifyOff, item, state, flag) {
 		if (flag && notifyOn.length) {
-			$.each(notifyOn.split(','), function (i, e) {
+			$.each(notifyOn.split(' '), function (i, e) {
 				App.mediator.notify(e, {item: item, state: state, flag: flag});
 			});
 		} else if (!flag && notifyOff.length) {
-			$.each(notifyOff.split(','), function (i, e) {
+			$.each(notifyOff.split(' '), function (i, e) {
 				App.mediator.notify(e, {item: item, state: state, flag: flag});
 			});
 		}

--- a/src/modules/change-state.js
+++ b/src/modules/change-state.js
@@ -48,11 +48,11 @@
 
 	var notifyChanges = function (notifyOn, notifyOff, item, state, flag) {
 		if (flag && notifyOn.length) {
-			$.each(notifyOn.split(' '), function (i, e) {
+			$.each(notifyOn.split(/\s|,/), function (i, e) {
 				App.mediator.notify(e, {item: item, state: state, flag: flag});
 			});
 		} else if (!flag && notifyOff.length) {
-			$.each(notifyOff.split(' '), function (i, e) {
+			$.each(notifyOff.split(/\s|,/), function (i, e) {
 				App.mediator.notify(e, {item: item, state: state, flag: flag});
 			});
 		}


### PR DESCRIPTION
A bit weird. I personally prefer the commas, but this change is better for readbility in our XSLT stack.

Right now, if we notify multiple things with one state, we need to separate everything by a comma and our "<add />" logic only add spaces.

so instead of this: `<add data-visible-state-notify-off="site.addScroll,autoOembed.pauseAll" />`

we can do this:

```
<add data-visible-state-notify-off="site.addScroll" />
 <add data-visible-state-notify-off="autoOembed.pauseAll" />
```