### PR TITLE
Add option to remove hash for UpdateQsFragment

### DIFF
--- a/src/modules/url-changer.js
+++ b/src/modules/url-changer.js
@@ -229,7 +229,7 @@
 				}
 
 				//Append back hash value
-				if (currentHash && currentHash.length) {
+				if (!options.removeHash && currentHash && currentHash.length) {
 					currentPageFragment += '#' + currentHash;
 				}
 


### PR DESCRIPTION
When updating the qs, we sometime don't want to keep the hash. I have left the default behaviour where it keeps the hash and added an option to remove it.