### PR TITLE
Use the whole fragment changed for the article handle

### DIFF
--- a/src/pages/default-detail-page.js
+++ b/src/pages/default-detail-page.js
@@ -26,7 +26,7 @@
 			var frag = !!data ? data : '';
 
 			if (!isFirstFragment) {
-				changer.navigateTo(frag.split('?')[0].split('/')[0]);
+				changer.navigateTo(frag.split('#')[0]);
 			} else {
 				isFirstFragment = false;
 			}


### PR DESCRIPTION
I added the label `bug` cause our XSLT that generates the articles handles are already ready for this change.

So the default detail page would take the whole handle (exept the hash in the URL of course) to display it's content. That includes query-strings.

What motivated this change was for support of pages with multiple parameters in the URL /en/{handle1}/{handle2}/. This change works well for the framwork and the page treat is as another article which is fine in that context.

 And yeah, query-string support for quick an easy filter page with this model. 