### PR TITLE
Ignore query string for canonical and title updater

### DIFF
--- a/src/modules/canonical-updater.js
+++ b/src/modules/canonical-updater.js
@@ -52,8 +52,10 @@
 				}
 			});
 
-			if (!!!data.url) {
+			if (!data.url) {
 				data.url = window.location.pathname;
+			} else {
+				data.url = data.url.split('?')[0];
 			}
 
 			canonicalList[data.url] = canonicalUrl;

--- a/src/modules/title-updater.js
+++ b/src/modules/title-updater.js
@@ -24,8 +24,10 @@
 					return true;
 				}
 			});
-			if (!!!data.url) {
+			if (!data.url) {
 				data.url = window.location.pathname;
+			} else {
+				data.url = data.url.split('?')[0];
 			}
 			titleList[data.url] = title;
 		}


### PR DESCRIPTION
ignore query string when storing a title because when used, it is compared againt window.location.pathname which does not contain the query string.