### PR TITLE
IE11 URL API compatibility issues

### DIFF
--- a/src/modules/link-selector.js
+++ b/src/modules/link-selector.js
@@ -40,6 +40,10 @@
 			fakeAnchor.prop('href', t.attr('href'));
 			pathname = fakeAnchor.prop('pathname');
 
+			if (!!App.device.internetexplorer) {
+				pathname = '/' + pathname;
+			}
+
 			$.each(pathname.split('/'), function (index, element) {
 				if (!!element && element === currentPath.split('/')[index]) {
 					matches.push(element);

--- a/src/modules/link-selector.js
+++ b/src/modules/link-selector.js
@@ -40,7 +40,8 @@
 			fakeAnchor.prop('href', t.attr('href'));
 			pathname = fakeAnchor.prop('pathname');
 
-			if (!!App.device.internetexplorer) {
+			// IE respects the spec, for once...
+			if (pathname.charAt(0) !== '/') {
 				pathname = '/' + pathname;
 			}
 


### PR DESCRIPTION
in ie 11. window.location.pathname respect the URL API spec that a path always starts with `/` but this API is not repected on elements props. Added an exeption for ie.