### PR TITLE
Add window-events

### DIFF
--- a/src/fx/window-events.js
+++ b/src/fx/window-events.js
@@ -1,0 +1,53 @@
+/**
+ * Centralize window events to avoid duplicates and improve global performance
+ * @author Deux Huit Huit
+ *
+ * App.fx.notify('window.on', {
+ * 		event: 'event', // (eg. 'scroll', 'resize', 'orientationchange', etc)
+ * 		handler: myHandlerFunction
+ * });
+ *
+ * App.fx.notify('window.off', {
+ * 		event: 'sameevent',
+ * 		handler: sameHandler
+ * });
+ *
+ */
+(function () {
+	'use strict';
+
+	const listeners = {};
+
+	const handleEvents = (event) => {
+		const handlers = listeners[event.type];
+		handlers.forEach((handler) => {
+			handler(event);
+		});
+	};
+
+	const on = (key, { event, handler }) => {
+		const evt = listeners[event];
+		if (evt) {
+			evt.add(handler);
+			return;
+		}
+		listeners[event] = new Set();
+		listeners[event].add(handler);
+		window.addEventListener(event, handleEvents);
+	};
+
+	const off = (key, { event, handler }) => {
+		const evt = listeners[event];
+		if (!evt) {
+			return;
+		}
+		evt.delete(handler);
+		if (evt.size === 0) {
+			window.removeEventListener(event, handleEvents);
+			delete listeners[event];
+		}
+	};
+
+	App.fx.exports('window.on', on);
+	App.fx.exports('window.off', off);
+})();


### PR DESCRIPTION
window-events.js aims to eventually replace site-notifier.js.

Like site-notifier.js, it is made to centralize all window events in one place to avoid having the same event registered multiple times by various modules, improving global performance.

The difference is that no event is registered until at least one module registers it, so it is a bit more economical. It is also more flexible. Finally, site-notifier has to notify the whole array of modules (which can get quite large), whereas window-events only has to through the handlers associated with one event, which is bound to be faster.

Usage:

App.fx.notify('window.on', {
    event: 'resize',
    handler: onResize
});

In this case, window-events.js checks if the 'resize' event is already registered. If it is, it will add the handler to an array of handlers. If not, it will create a 'resize' property in the listeners object and initiate a new array with the handler in it.

To remove the listener:

App.fx.notify('window.off', {
    event: 'resize',
    handler: onResize
});

window-events.js will remove the handler, and if no other handler is present for this event after that, the event will be unregistered from the window.